### PR TITLE
Fixed error and made SQS resources external to the application. (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The theory behind the implementation is described in this article: [Exponential backoff and jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)
 
-This serverless application deploys an Amazon SQS queue, linked with a dead letter queue (DLQ). An AWS lambda function replays each message of the DLQ with an exponential backoff and jitter. After some unseccessful retries, messages are moved to a second DLQ.
+This serverless application deploys an AWS lambda function that replays each message of the specified DLQ with an exponential backoff and jitter. After some unseccessful retries the function throws an error which can move the message to a secondary DLQ.
 
 ## App Architecture
 
@@ -27,10 +27,7 @@ This serverless application deploys an Amazon SQS queue, linked with a dead lett
 
 ## Deployment Outputs
 
-1. `ReplayFunction` - My Lambda function name, which replays SQS messages.
-1. `MainQueueArn` - Main SQS queue.
-1. `ReplayDeadLetterQueue` - Internal SQS dead letter queue.
-1. `DeadLetterQueue`- SQS dead letter queue containing replayed messages still not processed
+1. `ReplayFunctionArn` - My ARN for the Lambda function if needed to be used externally.
 
 ## Security
 

--- a/src/config.py
+++ b/src/config.py
@@ -4,7 +4,6 @@ import os
 
 LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
 SQS_MAIN_URL = os.getenv('SQS_MAIN_URL')
-INTERVAL_SECONDS = int(os.getenv('INTERVAL_SECONDS'))
 MAX_ATTEMPS = int(os.getenv('MAX_ATTEMPS'))
 BACKOFF_RATE = int(os.getenv('BACKOFF_RATE'))
 MESSAGE_RETENTION_PERIOD = int(os.getenv('MESSAGE_RETENTION_PERIOD'))

--- a/src/replay.py
+++ b/src/replay.py
@@ -16,7 +16,6 @@ def handler(event, context):
     """Lambda function handler."""
     LOG.info('Received event: %s', event)
     LOG.debug('Main SQS queue ARN: %s', config.SQS_MAIN_URL)
-    LOG.debug('Interval(s): %s', config.INTERVAL_SECONDS)
     LOG.debug('Max attemps: %s', config.MAX_ATTEMPS)
     LOG.debug('Backoff rate: %s', config.BACKOFF_RATE)
     LOG.debug('Message retention period: %s', config.MESSAGE_RETENTION_PERIOD)

--- a/template.yml
+++ b/template.yml
@@ -11,130 +11,79 @@ Metadata:
     ReadmeUrl: ./README.md
     Labels: [sqs, dlq, replay, queue, backoff]
     HomePageUrl: https://github.com/aws-samples/amazon-sqs-dlq-replay-backoff
-    SemanticVersion: 1.0.0
+    SemanticVersion: 2.0.0
     SourceCodeUrl: https://github.com/aws-samples/amazon-sqs-dlq-replay-backoff
 
-  AWS::CloudFormation::Interface:
-    ParameterGroups:
-      - Label: 
-          default: "SQS default parameters"
-        Parameters: 
-          - DelaySeconds
-          - MaximumMessageSize
-          - MessageRetentionPeriod
-          - ReceiveMessageWaitTimeSeconds
-          - VisibilityTimeout
-          - maxReceiveCount
-      - Label: 
-          default: "Replay feature"
-        Parameters: 
-          - BackoffRate
-          - MaxAttempts
-
-Parameters:
-  LogLevel:
-    Type: String
-    Description: Log level for Lambda function logging, e.g., ERROR, INFO, DEBUG, etc
-    Default: DEBUG
-  DelaySeconds:
-    Description: The time in seconds that the delivery of all messages in the queue
-      is delayed. You can specify an integer value of 0 to 900 (15 minutes).
-    Type: Number
-    Default: 0
-  MaximumMessageSize:
-    Type: Number
-    Description: The limit of how many bytes that a message can contain before Amazon
-      SQS rejects it, 1024 bytes (1 KiB) to 262144 bytes (256 KiB)
-    Default: 262144
-  MessageRetentionPeriod:
-    Description: 'The number of seconds that Amazon SQS retains a message. You can
-      specify an integer value from 60 seconds (1 minute) to 1209600 seconds (14 days). '
-    Type: Number
-    Default: 345600
-  ReceiveMessageWaitTimeSeconds:
-    Description: Specifies the duration, in seconds, that the ReceiveMessage action call waits
-      until a message is in the queue in order to include it in the response, as opposed
-      to returning an empty response if a message is not yet available. 1 to 20
-    Type: Number
-    Default: 0
-  VisibilityTimeout:
-    Description: This should be longer than the time it would take to process and
-      delete a message, this should not exceed 12 hours.
-    Type: Number
-    Default: 30
-  maxReceiveCount:
-    Description: The number of times a message is delivered to the source queue before being moved to the dead-letter queue. When the ReceiveCount for a message exceeds the maxReceiveCount for a queue, Amazon SQS moves the message to the dead-letter-queue.
-    Type: Number
-    Default: 1
-  MaxAttempts:
-    Description: An integer, representing the maximum number of replay attempts . If the error recurs more times than specified, retries cease. A value of 0 (zero) is permitted and indicates that the error or errors should never be retried.
-    Type: Number
-    Default: 3
-  BackoffRate:
-    Description: An integer that is the multiplier by which the replay interval increases on each attempt
-    Type: Number
-    Default: 2
+    AWS::CloudFormation::Interface:
+      ParameterGroups:
+        - Label: 
+            default: "SQS Parameters"
+          Parameters:
+            - MessageRetentionPeriod
+            - MainQueueURL
+            - MainQueueName
+            - DLQArn
+        - Label: 
+            default: "Lambda Parameters"
+          Parameters:
+            - LogLevel
+            - BackoffRate
+            - MaxAttempts
   
-Resources:
-  ReplayFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: src/
-      Handler: replay.handler
-      Runtime: python3.7
-      Tracing: Active
-      Timeout: !Ref 'VisibilityTimeout'
-      Policies:
-        - SQSSendMessagePolicy:
-            QueueName: !GetAtt MainQueue.QueueName
-      Events:
-        MySQSEvent:
-          Type: SQS
-          Properties:
-            Queue: !GetAtt ReplayDeadLetterQueue.Arn
-            BatchSize: 1
-      Environment:
-        Variables:
-          LOG_LEVEL: !Ref LogLevel
-          SQS_MAIN_URL: !Ref MainQueue
-          MAX_ATTEMPS: !Ref MaxAttempts
-          BACKOFF_RATE: !Ref BackoffRate
-          MESSAGE_RETENTION_PERIOD: !Ref MessageRetentionPeriod
-
-  MainQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      DelaySeconds: !Ref 'DelaySeconds'
-      MaximumMessageSize: !Ref 'MaximumMessageSize'
-      MessageRetentionPeriod: !Ref 'MessageRetentionPeriod'
-      ReceiveMessageWaitTimeSeconds: !Ref 'ReceiveMessageWaitTimeSeconds'
-      VisibilityTimeout: !Ref 'VisibilityTimeout'
-      KmsMasterKeyId: 'alias/aws/sqs'
-      RedrivePolicy:
-        deadLetterTargetArn: !GetAtt 'ReplayDeadLetterQueue.Arn'
-        maxReceiveCount: !Ref 'maxReceiveCount'
+  Parameters:
+    MessageRetentionPeriod:
+      Description: 'The number of seconds that Amazon SQS retains a message. You can
+        specify an integer value from 60 seconds (1 minute) to 1209600 seconds (14 days). This is used in the backoff calculation.'
+      Type: Number
+      Default: 345600
+    MainQueueURL:
+      Type: String
+      Description: The URL of the main queue to which messages will be replayed.
+    MainQueueName:
+      Type: String
+      Description: The Name of the main queue to which messages will be replayed.
+    DLQArn:
+      Type: String
+      Description: The ARN of the DLQ from which messages will be replayed.
+    LogLevel:
+      Type: String
+      Description: Log level for Lambda function logging, e.g., ERROR, INFO, DEBUG, etc
+      Default: DEBUG
+    MaxAttempts:
+      Description: An integer, representing the maximum number of replay attempts . If the error recurs more times than specified, retries cease. A value of 0 (zero) is permitted and indicates that the error or errors should never be retried.
+      Type: Number
+      Default: 3
+    BackoffRate:
+      Description: An integer that is the multiplier by which the replay interval increases on each attempt
+      Type: Number
+      Default: 2
+    
+  Resources:
+    ReplayFunction:
+      Type: AWS::Serverless::Function
+      Properties:
+        CodeUri: src/
+        Handler: replay.handler
+        Runtime: python3.7
+        Tracing: Active
+        Policies:
+          - SQSSendMessagePolicy:
+              QueueName: !Ref MainQueueName
+        Events:
+          MySQSEvent:
+            Type: SQS
+            Properties:
+              Queue: !Ref DLQArn
+              BatchSize: 1
+        Environment:
+          Variables:
+            LOG_LEVEL: !Ref LogLevel
+            SQS_MAIN_URL: !Ref MainQueueURL
+            MAX_ATTEMPS: !Ref MaxAttempts
+            BACKOFF_RATE: !Ref BackoffRate
+            MESSAGE_RETENTION_PERIOD: !Ref MessageRetentionPeriod
   
-  ReplayDeadLetterQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      VisibilityTimeout: !Ref 'VisibilityTimeout'
-      RedrivePolicy:
-        deadLetterTargetArn: !GetAtt 'DeadLetterQueue.Arn'
-        maxReceiveCount: 1
-  
-  DeadLetterQueue:
-    Type: AWS::SQS::Queue
-
-Outputs:
-  ReplayFunction:
-    Description: "Lambda Function Name"
-    Value: !Ref ReplayFunction
-  MainQueueArn:
-    Description: "Main SQS queue ARN"
-    Value: !GetAtt MainQueue.Arn
-  ReplayDeadLetterQueue:
-    Description: "Replay SQS dead letter queue ARN, managed by the Lambda Function"
-    Value: !GetAtt 'ReplayDeadLetterQueue.Arn'
-  DeadLetterQueue:
-    Description: "SQS dead letter queue ARN, managed manually"
-    Value: !GetAtt 'DeadLetterQueue.Arn'
+  Outputs:
+    ReplayFunctionArn:
+      Description: "Lambda Function ARN"
+      Value: !GetAtt ReplayFunction.Arn

--- a/test/env.json
+++ b/test/env.json
@@ -2,7 +2,6 @@
     "ReplayFunction": {
       "LOG_LEVEL": "DEBUG",
       "SQS_MAIN_URL": "https://sqs.eu-west-1.amazonaws.com/862440218923/sqs-dlq-replay-MainQeue-2D58PFOE4XIV",
-      "INTERVAL_SECONDS": 5,
       "MAX_ATTEMPS": 5,
       "BACKOFF_RATE": 2,
       "MESSAGE_RETENTION_PERIOD": 200


### PR DESCRIPTION
* Removed environment variable INTERVAL_SECONDS as it's not used and isn't passed into the Lambda function causing errors.

Error in Lambda this resolves:
[ERROR] TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
Traceback (most recent call last):
  File "/var/lang/lib/python3.7/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/var/lang/lib/python3.7/imp.py", line 171, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 696, in _load
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/var/task/replay.py", line 6, in <module>
    import lambdalogging
  File "/var/task/lambdalogging.py", line 8, in <module>
    import config
  File "/var/task/config.py", line 7, in <module>
    INTERVAL_SECONDS = int(os.getenv('INTERVAL_SECONDS'))

* Made SQS queues external.

Removed SQS resources from the template and instead require they be specified as parameters.